### PR TITLE
Share screen feature

### DIFF
--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -121,7 +121,7 @@ export const roomJWTprovider = async (
   try {
     const response = await mvdTech.post(
       '/room-jwtprovider',
-      JSON.stringify({ spaceId: roomId, participantId: `clarar@qualabs.com${Math.random()}` }),
+      JSON.stringify({ spaceId: roomId }),
       {
         headers: {
           Authorization: `Bearer ${process.env.REACT_APP_SUPABASE_KEY}`,

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -109,6 +109,7 @@ export const addRoomToDb = (data, onSuccess = null, onError = null) => async () 
 
 export const roomJWTprovider = async (
   roomId,
+  // isSharingScreen = false,
   onError = null,
   onSuccess = null,
   onNotFound = null,

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -121,7 +121,7 @@ export const roomJWTprovider = async (
   try {
     const response = await mvdTech.post(
       '/room-jwtprovider',
-      JSON.stringify({ spaceId: roomId }),
+      JSON.stringify({ spaceId: roomId, participantId: `clarar@qualabs.com${Math.random()}` }),
       {
         headers: {
           Authorization: `Bearer ${process.env.REACT_APP_SUPABASE_KEY}`,

--- a/frontend/src/components/RoomControls.jsx
+++ b/frontend/src/components/RoomControls.jsx
@@ -49,57 +49,65 @@ function RoomControls(props) {
         position: 'fixed', bottom: 0, left: 'calc(50% - 103px)',
       }}
     >
-      <Tooltip title={!localTracks.video || localTracks.video.muted ? '' : ''}>
-
-        <Button
-          size="large"
-          disabled={!localTracks.video}
-          onClick={() => toggleMuteTrack(localTracks.video)}
-        >
-          {!localTracks.video || localTracks.video.muted ? (
-            <VideocamOffOutlinedIcon />
-          ) : (
-            <VideocamIcon />
-          )}
-        </Button>
+      <Tooltip title={!localTracks.video || localTracks.video.muted ? 'Turn On Camera' : 'Turn Off Camera'}>
+        <div style={{ padding: '2px' }}>
+          <Button
+            size="large"
+            disabled={!localTracks.video}
+            onClick={() => toggleMuteTrack(localTracks.video)}
+          >
+            {!localTracks.video || localTracks.video.muted ? (
+              <VideocamOffOutlinedIcon />
+            ) : (
+              <VideocamIcon />
+            )}
+          </Button>
+        </div>
       </Tooltip>
 
       <Tooltip title={!localTracks.audio || localTracks.audio.muted ? 'Unmute' : 'Mute'}>
-
-        <Button
-          size="large"
-          disabled={!localTracks.audio}
-          onClick={() => toggleMuteTrack(localTracks.audio)}
-        >
-          {!localTracks.audio || localTracks.audio.muted ? (
-            <MicOffOutlinedIcon />
-          ) : (
-            <MicIcon />
-          )}
-        </Button>
+        <div style={{ padding: '2px' }}>
+          <Button
+            size="large"
+            disabled={!localTracks.audio}
+            onClick={() => toggleMuteTrack(localTracks.audio)}
+          >
+            {!localTracks.audio || localTracks.audio.muted ? (
+              <MicOffOutlinedIcon />
+            ) : (
+              <MicIcon />
+            )}
+          </Button>
+        </div>
       </Tooltip>
 
-      <Tooltip title={!isSharingScreen ? '' : ''}>
-        <Button
-          size="large"
-          hover="onHoverTest"
-          onClick={() => shareScreen()}
-        >
-          {!isSharingScreen ? (
-            <ScreenShareIcon />
-          ) : (
-            <StopScreenShareIcon />
-          )}
-        </Button>
+      <Tooltip title={!isSharingScreen ? 'Share screen' : 'Stop sharing screen'}>
+        <div style={{ padding: '2px' }}>
+          <Button
+            size="large"
+            hover="onHoverTest"
+            onClick={() => shareScreen()}
+          >
+            {!isSharingScreen ? (
+              <ScreenShareIcon />
+            ) : (
+              <StopScreenShareIcon />
+            )}
+          </Button>
+        </div>
+      </Tooltip>
+      <Tooltip title="Leave room">
+        <div style={{ padding: '2px' }}>
+          <Button
+            size="large"
+            color="error"
+            onClick={endCall}
+          >
+            <CancelIcon />
+          </Button>
+        </div>
       </Tooltip>
 
-      <Button
-        size="large"
-        color="error"
-        onClick={endCall}
-      >
-        <CancelIcon />
-      </Button>
     </ButtonGroup>
   );
 }

--- a/frontend/src/components/RoomControls.jsx
+++ b/frontend/src/components/RoomControls.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 
-import { ButtonGroup, Button } from '@mui/material';
+import { ButtonGroup, Button, Tooltip } from '@mui/material';
 import {
   Videocam as VideocamIcon,
   VideocamOffOutlined as VideocamOffOutlinedIcon,
@@ -49,39 +49,49 @@ function RoomControls(props) {
         position: 'fixed', bottom: 0, left: 'calc(50% - 103px)',
       }}
     >
-      <Button
-        size="large"
-        disabled={!localTracks.video}
-        onClick={() => toggleMuteTrack(localTracks.video)}
-      >
-        {!localTracks.video || localTracks.video.muted ? (
-          <VideocamOffOutlinedIcon />
-        ) : (
-          <VideocamIcon />
-        )}
-      </Button>
-      <Button
-        size="large"
-        disabled={!localTracks.audio}
-        onClick={() => toggleMuteTrack(localTracks.audio)}
-      >
-        {!localTracks.audio || localTracks.audio.muted ? (
-          <MicOffOutlinedIcon />
-        ) : (
-          <MicIcon />
-        )}
-      </Button>
+      <Tooltip title={!localTracks.video || localTracks.video.muted ? '' : ''}>
 
-      <Button
-        size="large"
-        onClick={() => shareScreen()}
-      >
-        {!isSharingScreen ? (
-          <ScreenShareIcon />
-        ) : (
-          <StopScreenShareIcon />
-        )}
-      </Button>
+        <Button
+          size="large"
+          disabled={!localTracks.video}
+          onClick={() => toggleMuteTrack(localTracks.video)}
+        >
+          {!localTracks.video || localTracks.video.muted ? (
+            <VideocamOffOutlinedIcon />
+          ) : (
+            <VideocamIcon />
+          )}
+        </Button>
+      </Tooltip>
+
+      <Tooltip title={!localTracks.audio || localTracks.audio.muted ? 'Unmute' : 'Mute'}>
+
+        <Button
+          size="large"
+          disabled={!localTracks.audio}
+          onClick={() => toggleMuteTrack(localTracks.audio)}
+        >
+          {!localTracks.audio || localTracks.audio.muted ? (
+            <MicOffOutlinedIcon />
+          ) : (
+            <MicIcon />
+          )}
+        </Button>
+      </Tooltip>
+
+      <Tooltip title={!isSharingScreen ? '' : ''}>
+        <Button
+          size="large"
+          hover="onHoverTest"
+          onClick={() => shareScreen()}
+        >
+          {!isSharingScreen ? (
+            <ScreenShareIcon />
+          ) : (
+            <StopScreenShareIcon />
+          )}
+        </Button>
+      </Tooltip>
 
       <Button
         size="large"

--- a/frontend/src/components/RoomControls.jsx
+++ b/frontend/src/components/RoomControls.jsx
@@ -37,7 +37,6 @@ function RoomControls(props) {
   };
 
   const shareScreen = async () => {
-    console.log('issharing:', isSharingScreen);
     updateScreen(isSharingScreen);
   };
 

--- a/frontend/src/components/RoomControls.jsx
+++ b/frontend/src/components/RoomControls.jsx
@@ -18,7 +18,7 @@ function RoomControls(props) {
   const navigate = useNavigate();
 
   const {
-    updateScreen, isSharingScreen, localTracks, updateLocalTracksMuted, leaveRoom, disabled,
+    updateScreenShare, isSharingScreen, localTracks, updateLocalTracksMuted, leaveRoom, disabled,
   } = props;
 
   const toggleMuteTrack = (t) => {
@@ -37,7 +37,7 @@ function RoomControls(props) {
   };
 
   const shareScreen = async () => {
-    updateScreen(isSharingScreen);
+    updateScreenShare();
   };
 
   return (
@@ -72,19 +72,6 @@ function RoomControls(props) {
         )}
       </Button>
 
-      {/* <Button
-        size="large"
-        onClick={startSharingScreen}
-      >
-        <ScreenShareIcon />
-      </Button>
-      <Button
-        size="large"
-        onClick={stopSharingScreen}
-      >
-        <StopScreenShareIcon />
-      </Button> */}
-
       <Button
         size="large"
         onClick={() => shareScreen()}
@@ -109,7 +96,7 @@ function RoomControls(props) {
 
 RoomControls.propTypes = {
   localTracks: PropTypes.object,
-  updateScreen: PropTypes.func.isRequired,
+  updateScreenShare: PropTypes.func.isRequired,
   updateLocalTracksMuted: PropTypes.func.isRequired,
   leaveRoom: PropTypes.func.isRequired,
   disabled: PropTypes.bool,

--- a/frontend/src/components/RoomControls.jsx
+++ b/frontend/src/components/RoomControls.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/forbid-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
@@ -9,13 +10,15 @@ import {
   Mic as MicIcon,
   MicOffOutlined as MicOffOutlinedIcon,
   Cancel as CancelIcon,
+  ScreenShare as ScreenShareIcon,
+  StopScreenShare as StopScreenShareIcon,
 } from '@mui/icons-material';
 
 function RoomControls(props) {
   const navigate = useNavigate();
 
   const {
-    localTracks, updateLocalTracksMuted, leaveRoom, disabled,
+    updateScreen, isSharingScreen, localTracks, updateLocalTracksMuted, leaveRoom, disabled,
   } = props;
 
   const toggleMuteTrack = (t) => {
@@ -31,6 +34,11 @@ function RoomControls(props) {
   const endCall = () => {
     leaveRoom();
     navigate('/rooms');
+  };
+
+  const shareScreen = async () => {
+    console.log('issharing:', isSharingScreen);
+    updateScreen(isSharingScreen);
   };
 
   return (
@@ -64,6 +72,31 @@ function RoomControls(props) {
           <MicIcon />
         )}
       </Button>
+
+      {/* <Button
+        size="large"
+        onClick={startSharingScreen}
+      >
+        <ScreenShareIcon />
+      </Button>
+      <Button
+        size="large"
+        onClick={stopSharingScreen}
+      >
+        <StopScreenShareIcon />
+      </Button> */}
+
+      <Button
+        size="large"
+        onClick={() => shareScreen()}
+      >
+        {!isSharingScreen ? (
+          <ScreenShareIcon />
+        ) : (
+          <StopScreenShareIcon />
+        )}
+      </Button>
+
       <Button
         size="large"
         color="error"
@@ -76,16 +109,19 @@ function RoomControls(props) {
 }
 
 RoomControls.propTypes = {
-  // eslint-disable-next-line react/forbid-prop-types
   localTracks: PropTypes.object,
+  updateScreen: PropTypes.func.isRequired,
   updateLocalTracksMuted: PropTypes.func.isRequired,
   leaveRoom: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  isSharingScreen: PropTypes.bool,
 };
 
 RoomControls.defaultProps = {
   localTracks: { audio: null, video: null },
   disabled: true,
+  isSharingScreen: false,
+
 };
 
 export default RoomControls;

--- a/frontend/src/components/ShareScreen.jsx
+++ b/frontend/src/components/ShareScreen.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function ShareScreen() {
+  return (
+    <div>
+      Share screen component
+    </div>
+
+  );
+}
+
+export default ShareScreen;

--- a/frontend/src/lib/webrtc.js
+++ b/frontend/src/lib/webrtc.js
@@ -94,22 +94,14 @@ export class LocalParticipant extends Participant {
   }
 
   async startScreenShare() {
-    // let tracksToPublish = [];
     const displayMediaOptions = {
       video: {
         cursor: 'always',
-        // height: 1000,
-        // width: 1200,
       },
       audio: false,
     };
     const screenStreams = await getDisplayMedia(displayMediaOptions);
-    const screenStream = screenStreams?.find(
-      (track) => track.source === 'screenshare',
-    );
-    const tracksToPublish = screenStream[0];
-
-    const publishedTracks = await this.provider.publishTracks(tracksToPublish); // returns Mux Track
+    const publishedTracks = await this.provider.publishTracks(screenStreams); // returns Mux Track
     return publishedTracks.map((t) => new Track(t)); // wrap into our Track
   }
 

--- a/frontend/src/lib/webrtc.js
+++ b/frontend/src/lib/webrtc.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import EventEmitter from 'events';
 import {
-  Space, SubscriptionMode, getUserMedia, SpaceEvent, ParticipantEvent, TrackEvent,
+  Space, SubscriptionMode, getUserMedia, getDisplayMedia, SpaceEvent, ParticipantEvent, TrackEvent,
 } from '@mux/spaces-web';
 
 // TODO we should have a config somewhere which tells us what to use
@@ -88,6 +88,26 @@ export class LocalParticipant extends Participant {
     } else {
       throw new Error('Unexpected parameters passes to publishTracks');
     }
+
+    const publishedTracks = await this.provider.publishTracks(tracksToPublish); // returns Mux Track
+    return publishedTracks.map((t) => new Track(t)); // wrap into our Track
+  }
+
+  async startScreenShare() {
+    // let tracksToPublish = [];
+    const displayMediaOptions = {
+      video: {
+        cursor: 'always',
+        // height: 1000,
+        // width: 1200,
+      },
+      audio: false,
+    };
+    const screenStreams = await getDisplayMedia(displayMediaOptions);
+    const screenStream = screenStreams?.find(
+      (track) => track.source === 'screenshare',
+    );
+    const tracksToPublish = screenStream[0];
 
     const publishedTracks = await this.provider.publishTracks(tracksToPublish); // returns Mux Track
     return publishedTracks.map((t) => new Track(t)); // wrap into our Track

--- a/frontend/src/views/Room.jsx
+++ b/frontend/src/views/Room.jsx
@@ -36,6 +36,8 @@ function Room() {
   const [localStream, setLocalStream] = useState();
   // this helps keep track of muting/unmuting with RoomControls
   const [localTracks, setLocalTracks] = useState({ video: null, audio: null });
+  const [isSharingScreen, setIsSharingScreen] = useState(false);
+
   const [remoteStreams, setRemoteStreams] = useState([]);
   const [roomNotFound, setRoomNotFound] = useState(false);
   // const [participants, setParticipants] = useState([]);
@@ -128,6 +130,7 @@ function Room() {
         // same participant.
         if (remoteStreamsRef.current.has(remoteParticipant.id)) {
           const streamData = remoteStreamsRef.current.get(remoteParticipant.id);
+          // console.log('streamData', streamData);
           streamData.stream.addTrack(track.mediaStreamTrack);
           streamData[`${track.kind}Muted`] = track.muted;
         } else {
@@ -139,7 +142,6 @@ function Room() {
           );
         }
         setRemoteStreamsRef(remoteStreamsRef.current);
-
         // add event handler for Muted/Unmuted events
         track.on('Muted', () => {
           const streamData = remoteStreamsRef.current.get(remoteParticipant.id);
@@ -167,18 +169,26 @@ function Room() {
       roomRef.current = newRoom;
       const tracks = await newParticipant.publishTracks(
         { constraints: { video: true, audio: true } },
+
       );
+
       const stream = new MediaStream();
-
       const newLocalTracks = { ...localTracks };
-
       tracks.forEach((track) => {
         stream.addTrack(track.mediaStreamTrack);
         newLocalTracks[track.kind] = track;
       });
-
+      console.log('182', isSharingScreen);
+      // if (true) {
+      //   const screenTrack = await newParticipant.startScreenShare();
+      //   console.log(screenTrack);
+      //   stream.addTrack(screenTrack.mediaStreamTrack);
+      //   console.log('newLocalTracks', newLocalTracks);
+      //   // newLocalTracks.screen = screenTrack;
+      // }
       setLocalStream(stream);
       setLocalTracks(newLocalTracks);
+      console.log(localTracks);
       // setUserParticipant(newParticipant);
       subscribeToRemoteStreams(newRoom);
     };
@@ -188,8 +198,15 @@ function Room() {
   }, []);
 
   const updateLocalTracksMuted = (kind, muted) => {
+    console.log(kind);
     localTracks[kind].muted = muted;
     setLocalTracks({ ...localTracks });
+  };
+
+  const updateScreen = () => {
+    console.log('update screen');
+    setIsSharingScreen(!isSharingScreen);
+    console.log(isSharingScreen);
   };
 
   const localStreamStyle = {
@@ -198,6 +215,7 @@ function Room() {
     bottom: 0,
     right: 0,
   };
+
   return (
     <>
       {
@@ -233,6 +251,8 @@ function Room() {
       }
 
       <RoomControls
+        updateScreen={updateScreen}
+        isSharingScreen={isSharingScreen}
         localTracks={localTracks}
         updateLocalTracksMuted={updateLocalTracksMuted}
         leaveRoom={leaveRoom}

--- a/frontend/src/views/Room.jsx
+++ b/frontend/src/views/Room.jsx
@@ -130,7 +130,6 @@ function Room() {
         // same participant.
         if (remoteStreamsRef.current.has(remoteParticipant.id)) {
           const streamData = remoteStreamsRef.current.get(remoteParticipant.id);
-          // console.log('streamData', streamData);
           streamData.stream.addTrack(track.mediaStreamTrack);
           streamData[`${track.kind}Muted`] = track.muted;
         } else {
@@ -142,6 +141,7 @@ function Room() {
           );
         }
         setRemoteStreamsRef(remoteStreamsRef.current);
+
         // add event handler for Muted/Unmuted events
         track.on('Muted', () => {
           const streamData = remoteStreamsRef.current.get(remoteParticipant.id);
@@ -169,16 +169,13 @@ function Room() {
       roomRef.current = newRoom;
       const tracks = await newParticipant.publishTracks(
         { constraints: { video: true, audio: true } },
-
       );
-
       const stream = new MediaStream();
       const newLocalTracks = { ...localTracks };
       tracks.forEach((track) => {
         stream.addTrack(track.mediaStreamTrack);
         newLocalTracks[track.kind] = track;
       });
-      console.log('182', isSharingScreen);
       // if (true) {
       //   const screenTrack = await newParticipant.startScreenShare();
       //   console.log(screenTrack);
@@ -188,7 +185,6 @@ function Room() {
       // }
       setLocalStream(stream);
       setLocalTracks(newLocalTracks);
-      console.log(localTracks);
       // setUserParticipant(newParticipant);
       subscribeToRemoteStreams(newRoom);
     };
@@ -198,15 +194,12 @@ function Room() {
   }, []);
 
   const updateLocalTracksMuted = (kind, muted) => {
-    console.log(kind);
     localTracks[kind].muted = muted;
     setLocalTracks({ ...localTracks });
   };
 
   const updateScreen = () => {
-    console.log('update screen');
     setIsSharingScreen(!isSharingScreen);
-    console.log(isSharingScreen);
   };
 
   const localStreamStyle = {


### PR DESCRIPTION
Share screen functionality implemented.
As a first approach (that probably could be improved), in order to let a user share the screen a new WebRoom is created. The share screen track is treated as a new participant. 
For this implementation it would be necessary to pass to the roomJWTprovider edge function a flag `isSharingScreen` to know that the participant is not a participant itself, but a screen from an existing participant.


![image](https://user-images.githubusercontent.com/98163437/221263831-a2473a0a-eccb-4b20-acf6-afb790830564.png)
