### PR TITLE
update linter files

### DIFF
--- a/backend/.eslintrc
+++ b/backend/.eslintrc
@@ -6,18 +6,32 @@
     "jest": true
   },
   "rules": {
-    "quotes": ["error", "single"],
+    "linebreak-style": 0,
+    "quotes": [
+      "error",
+      "single"
+    ],
     "comma-dangle": 0,
     "consistent-return": 0,
-    "function-paren-newline": ["error", "never"],
-    "implicit-arrow-linebreak": ["off"],
+    "function-paren-newline": [
+      "error",
+      "never"
+    ],
+    "implicit-arrow-linebreak": [
+      "off"
+    ],
     "no-param-reassign": 0,
     "no-underscore-dangle": 0,
     "no-shadow": 0,
     "no-console": 0,
     "no-plusplus": 0,
     "no-unused-expressions": 0,
-    "no-unused-vars": ["error", { "argsIgnorePattern": "next" }],
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "next"
+      }
+    ],
     "import/prefer-default-export": "warn",
     "import/no-unresolved": "off"
   },
@@ -25,7 +39,9 @@
     // Match TypeScript Files
     // =================================
     {
-      "files": ["**/*.{ts,tsx}"],
+      "files": [
+        "**/*.{ts,tsx}"
+      ],
       "settings": {},
       "extends": [
         "eslint:recommended",
@@ -36,8 +52,9 @@
         "ecmaVersion": "latest",
         "sourceType": "module"
       },
-      "plugins": ["@typescript-eslint"],
-      "rules": {}
+      "plugins": [
+        "@typescript-eslint"
+      ]
     }
   ]
 }

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -1,0 +1,27 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "plugin:react/recommended",
+    "airbnb"
+  ],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react"
+  ],
+  "rules": {
+    "linebreak-style": 0
+  },
+  "ignorePatterns": [
+    "src/plugins"
+  ]
+}


### PR DESCRIPTION
There's an issue with how windows deals with linebreaks and that is causing issues only on Windows(on linux works fine).
As a consequence of this I added one eslint file to the frontend folder and modified the backend linter.