### PR TITLE
fix linebreak style

### DIFF
--- a/backend/.eslintrc
+++ b/backend/.eslintrc
@@ -6,26 +6,42 @@
     "jest": true
   },
   "rules": {
-    "quotes": ["error", "single"],
+    "quotes": [
+      "error",
+      "single"
+    ],
     "comma-dangle": 0,
     "consistent-return": 0,
-    "function-paren-newline": ["error", "never"],
-    "implicit-arrow-linebreak": ["off"],
+    "function-paren-newline": [
+      "error",
+      "never"
+    ],
+    "implicit-arrow-linebreak": [
+      "off"
+    ],
     "no-param-reassign": 0,
     "no-underscore-dangle": 0,
     "no-shadow": 0,
     "no-console": 0,
     "no-plusplus": 0,
     "no-unused-expressions": 0,
-    "no-unused-vars": ["error", { "argsIgnorePattern": "next" }],
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "next"
+      }
+    ],
     "import/prefer-default-export": "warn",
-    "import/no-unresolved": "off"
+    "import/no-unresolved": "off",
+    "linebreak-style": 0
   },
   "overrides": [
     // Match TypeScript Files
     // =================================
     {
-      "files": ["**/*.{ts,tsx}"],
+      "files": [
+        "**/*.{ts,tsx}"
+      ],
       "settings": {},
       "extends": [
         "eslint:recommended",
@@ -36,7 +52,9 @@
         "ecmaVersion": "latest",
         "sourceType": "module"
       },
-      "plugins": ["@typescript-eslint"],
+      "plugins": [
+        "@typescript-eslint"
+      ],
       "rules": {}
     }
   ]

--- a/backend/.eslintrc
+++ b/backend/.eslintrc
@@ -32,8 +32,7 @@
       }
     ],
     "import/prefer-default-export": "warn",
-    "import/no-unresolved": "off",
-    "linebreak-style": 0
+    "import/no-unresolved": "off"
   },
   "overrides": [
     // Match TypeScript Files

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -1,0 +1,49 @@
+{
+  "extends": [
+    "plugin:react/recommended",
+    "airbnb"
+  ],
+  "env": {
+    "browser": true
+  },
+  "rules": {
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "comma-dangle": 0,
+    "consistent-return": 0,
+    "function-paren-newline": [
+      0,
+      "never"
+    ],
+    "implicit-arrow-linebreak": [
+      "off"
+    ],
+    "no-param-reassign": 0,
+    "no-underscore-dangle": 0,
+    "no-shadow": 0,
+    "no-console": 0,
+    "no-plusplus": 0,
+    "no-unused-expressions": 0,
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "next"
+      }
+    ],
+    "import/prefer-default-export": "warn",
+    "import/no-unresolved": "off",
+    "linebreak-style": 0
+  },
+  "plugins": [
+    "react"
+  ],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint . --ext .js,.ts,.jsx",
+    "lint:fix": "npm run lint -- --fix"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/src/views/Room.jsx
+++ b/frontend/src/views/Room.jsx
@@ -250,7 +250,6 @@ function Room() {
       dispatch(cleanRoom());
       leaveRoom();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const updateLocalTracksMuted = (kind, muted) => {


### PR DESCRIPTION
This fixes #131 
eslint was checking on the linebreaks and that was problematic since some of the contributors were using windows and others were using unix.
the best solution we found was basically to remove the eslint check on linebreaks since we already now that every time you clone the project git automatically will place the linebreaks of the operating system you have so there's no need to have this lint check.