### PR TITLE
Change the name of the platform in multiple places

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,21 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,12 +22,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Hybrid Meeting Platform</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <title>Hybridly</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -39,5 +38,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/frontend/src/views/Root.jsx
+++ b/frontend/src/views/Root.jsx
@@ -48,8 +48,16 @@ function Root() {
       <div style={{ height: '8vh' }}>
         <AppBar position="relative" sx={{ height: '100%', justifyContent: 'center' }}>
           <Toolbar>
-            <MenuItem variant="h6" sx={{ flexGrow: 1, textDecoration: 'none' }} component={RouterLink} to="/">
-              Monte&lt;video&gt; Tech Summer Camp
+            <MenuItem
+              sx={{
+                flexGrow: 1,
+                textDecoration: 'none',
+                letterSpacing: 1,
+              }}
+              component={RouterLink}
+              to="/"
+            >
+              Hybridly
             </MenuItem>
             {auth?.email && auth?.token && (
               <div>


### PR DESCRIPTION
The name of the platform has been changed on the Tab, and in the Navbar it is now called Hybridly.