### PR TITLE
Add Edit Room button to RoomsList

### DIFF
--- a/frontend/src/components/RoomsList.jsx
+++ b/frontend/src/components/RoomsList.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
+
 import {
   List, ListItem, ListItemButton, ListItemText, Typography, IconButton,
 } from '@mui/material';
-import DeleteIcon from '@mui/icons-material/Delete';
+import {
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+} from '@mui/icons-material';
+
 import { useDispatch } from 'react-redux';
 import { deleteRoom } from '../actions';
 
@@ -43,7 +48,19 @@ function RoomsList(props) {
               <ListItemButton component={RouterLink} to={`/rooms/${room.providerId}`}>
                 <ListItemText primary={room.name} secondary={createdByStr} />
               </ListItemButton>
-              <IconButton aria-label="delete" size="large" onClick={() => dispatch(deleteRoom(room.providerId))}>
+              <IconButton
+                aria-label="edit"
+                size="large"
+                component={RouterLink}
+                to={`/rooms/${room.providerId}/edit`}
+              >
+                <EditIcon fontSize="inherit" />
+              </IconButton>
+              <IconButton
+                aria-label="delete"
+                size="large"
+                onClick={() => dispatch(deleteRoom(room.providerId))}
+              >
                 <DeleteIcon fontSize="inherit" />
               </IconButton>
             </ListItem>


### PR DESCRIPTION
Fixes #115.

The button takes to the EditRoom page at the route `/rooms/${room.providerId}/edit`.

<img width="450" alt="image" src="https://user-images.githubusercontent.com/31407403/229182840-e0b65938-cb20-4a7c-9e7a-acdb1b8df77c.png">
