### PR TITLE
140 Add priority to who has recently spoken

### DIFF
--- a/frontend/src/views/Room.jsx
+++ b/frontend/src/views/Room.jsx
@@ -56,6 +56,10 @@ function Room() {
       return -1;
     }
 
+    if (participant1.lastSpokenTime > participant2.lastSpokenTime) {
+      return -1;
+    }
+
     return 1;
   };
 
@@ -121,6 +125,9 @@ function Room() {
   const updateIsSpeakingStatus = (id, newStatus) => {
     const streamData = remoteStreamsRef.current.get(id);
     streamData.speaking = newStatus;
+    if (newStatus) {
+      streamData.lastSpokenTime = Date.now();
+    }
     setRemoteStreamsRef(remoteStreamsRef.current);
   };
 
@@ -198,7 +205,12 @@ function Room() {
           remoteStreamsRef.current.set(
             remoteParticipant.id,
             {
-              audioStream, videoStream, [`${track.kind}Muted`]: track.muted, speaking: false, name: remoteParticipant.displayName,
+              audioStream,
+              videoStream,
+              [`${track.kind}Muted`]: track.muted,
+              speaking: false,
+              name: remoteParticipant.displayName,
+              lastSpokenTime: 0
             },
           );
         }


### PR DESCRIPTION
In the video you can see how the handsome man on the video speaks(video turns red) and stays on the left after finishing speaking. That is because even though is not speaking he has higher priority due to the fact that he is the participant who has more recently spoken.
@marcovidonis what do you think? I think it looks less jumpy now.

https://user-images.githubusercontent.com/121059628/229828560-a3b8dc1d-bb49-41c0-8382-4b8b2996cd76.mp4

Fix #140 

