### PR TITLE
prevent users/guest from deleting or editing rooms

### DIFF
--- a/frontend/src/components/RoomsList.jsx
+++ b/frontend/src/components/RoomsList.jsx
@@ -10,10 +10,11 @@ import {
   Edit as EditIcon,
 } from '@mui/icons-material';
 
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import Button from '@mui/material/Button';
 import { deleteRoom } from '../actions';
+import { ROLES } from '../utils/roles';
 
 const StyledButton = styled(Button)`
   &&.custom-button {
@@ -40,6 +41,7 @@ const StyledCard = styled(Card)`
 
 function RoomsList(props) {
   const dispatch = useDispatch();
+  const currentUser = useSelector((state) => state.user);
   const { list } = props; // TODO use store
   return (
     list.length ? (
@@ -76,22 +78,32 @@ function RoomsList(props) {
                     {createdByStr}
                   </Typography>
                 </CardContent>
-                <CardActions>
-                  <StyledButton className="custom-button" component={RouterLink} to={`/rooms/${room.providerId}`}>
-                    Join Room
-                  </StyledButton>
-                  <IconButton aria-label="delete" size="medium" onClick={() => dispatch(deleteRoom(room.providerId))}>
-                    <DeleteIcon fontSize="inherit" />
-                  </IconButton>
-                  <IconButton
-                    aria-label="edit"
-                    size="medium"
-                    component={RouterLink}
-                    to={`/rooms/${room.providerId}/edit`}
-                  >
-                    <EditIcon fontSize="inherit" />
-                  </IconButton>
-                </CardActions>
+                {currentUser?.role === ROLES.USER
+                  ? (
+                    <CardActions>
+                      <StyledButton className="custom-button" component={RouterLink} to={`/rooms/${room.providerId}`}>
+                        Join Room
+                      </StyledButton>
+                    </CardActions>
+                  )
+                  : (
+                    <CardActions>
+                      <StyledButton className="custom-button" component={RouterLink} to={`/rooms/${room.providerId}`}>
+                        Join Room
+                      </StyledButton>
+                      <IconButton aria-label="delete" size="medium" onClick={() => dispatch(deleteRoom(room.providerId))}>
+                        <DeleteIcon fontSize="inherit" />
+                      </IconButton>
+                      <IconButton
+                        aria-label="edit"
+                        size="medium"
+                        component={RouterLink}
+                        to={`/rooms/${room.providerId}/edit`}
+                      >
+                        <EditIcon fontSize="inherit" />
+                      </IconButton>
+                    </CardActions>
+                  )}
               </StyledCard>
             </Grid>
           );

--- a/frontend/src/hooks/useUserPermission.jsx
+++ b/frontend/src/hooks/useUserPermission.jsx
@@ -1,0 +1,19 @@
+import { useSelector } from 'react-redux';
+import { useEffect, useState } from 'react';
+
+const useUserPermission = () => {
+  const participants = useSelector((state) => state.room.participants);
+  const currentUser = useSelector((state) => state.user);
+  const [participantRole, setParticipantRole] = useState();
+  const participant = participants.find((p) => p.name === currentUser.email);
+
+  useEffect(() => {
+    if (participant) {
+      setParticipantRole(participant.role);
+    }
+  }, [participant]);
+
+  return participantRole;
+};
+
+export default useUserPermission;

--- a/frontend/src/utils/roles.js
+++ b/frontend/src/utils/roles.js
@@ -4,6 +4,8 @@ export const ROLES = {
   HOST: 'HOST',
   PRESENTER: 'PRESENTER',
   GUEST: 'GUEST',
+  ADMIN: 'admin',
+  USER: 'user'
 };
 
 const subscribeToRoleChanges = (roomId, handleRoleChange) => {

--- a/frontend/src/views/Room.jsx
+++ b/frontend/src/views/Room.jsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/material';
 
 import useWindowDimensions from '../hooks/useWindowDimesion';
+import useUserPermission from '../hooks/useUserPermission';
 import RoomControls from '../components/RoomControls';
 import Video from '../components/Video';
 
@@ -28,6 +29,7 @@ export async function roomLoader({ params }) {
 
 function Room() {
   const [room, setRoom] = useState();
+  const userRole = useUserPermission();
   // const [userParticipant, setUserParticipant] = useState();
   const [localStream, setLocalStream] = useState();
   // this helps keep track of muting/unmuting with RoomControls
@@ -36,15 +38,11 @@ function Room() {
   const [screenRoom, setScreenRoom] = useState();
   const [remoteStreams, setRemoteStreams] = useState([]);
   const [roomNotFound, setRoomNotFound] = useState(false);
-
   const roomId = useLoaderData();
-
   // create reference to access room state var in useEffect cleanup func
   const roomRef = useRef();
   const remoteStreamsRef = useRef(new Map());
   const currentUser = useSelector((state) => state.user);
-  const participants = useSelector((state) => state.room.participants);
-  const [participantRole, setParticipantRole] = useState();
   // const roomData = useSelector((state) => state.room);
   const dispatch = useDispatch();
   const { width = 0, height = 0 } = useWindowDimensions();
@@ -66,11 +64,6 @@ function Room() {
     }
 
     return 1;
-  };
-
-  const getUserRole = () => {
-    const participant = participants.find((p) => p.name === currentUser.email);
-    if (participant) setParticipantRole(participant.role);
   };
   const setRemoteStreamsRef = (data) => {
     remoteStreamsRef.current = data;
@@ -283,10 +276,6 @@ function Room() {
     };
   }, []);
 
-  useEffect(() => {
-    getUserRole();
-  }, [participants]);
-
   const updateLocalTracksMuted = (kind, muted) => {
     localTracks[kind].muted = muted;
     setLocalTracks({ ...localTracks });
@@ -418,7 +407,7 @@ function Room() {
         )
       }
       <RoomControls
-        permissionRole={participantRole}
+        permissionRole={userRole}
         updateScreenShare={updateScreenShare}
         isSharingScreen={isSharingScreen}
         localTracks={localTracks}


### PR DESCRIPTION
fixes #181 

The function to obtain permissions was moved to a generic hook to allow for reusability and prevent code duplication, and common users were denied the ability to delete or edit rooms.