### PR TITLE
block edit room route for non admin users

### DIFF
--- a/frontend/src/components/IsAdmin.jsx
+++ b/frontend/src/components/IsAdmin.jsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom';
+import React from 'react';
+import { store } from '../store';
+
+// eslint-disable-next-line react/prop-types
+function IsAdmin({ children }) {
+  const isLoggedIn = store.getState().user?.token;
+  if (isLoggedIn) {
+    const isAdmin = store.getState().user.role;
+    return isAdmin === 'admin' ? children : <Navigate to="/rooms" replace />;
+  }
+  return isLoggedIn === true ? children : <Navigate to="/signIn" replace />;
+}
+
+export default IsAdmin;

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from '@mui/material';
 import theme from './themes/theme';
 import './index.css';
 import { store } from './store';
-
+import IsAdmin from './components/IsAdmin';
 import Root from './views/Root';
 import SignIn from './views/SignIn';
 import SignUp from './views/SignUp';
@@ -47,9 +47,9 @@ const router = createBrowserRouter([
       {
         path: '/rooms/:roomId/edit',
         element: (
-          <RequireAuth>
+          <IsAdmin>
             <EditRoom />
-          </RequireAuth>
+          </IsAdmin>
         ),
         loader: roomLoader,
       },


### PR DESCRIPTION
fixes #190 
A new IsAdmin component was created to verify that the logged-in user is an admin in order to access the EditRoom route. If you are a user with any other role besides admin, you will be redirected back to the list of rooms. And if you are not logged in, you will be directed to the SignIn page.