### PR TITLE
Add Host Permison to users admin for each room

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.3.2",
+        "framer-motion": "^10.10.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -8793,6 +8794,44 @@
         "type": "patreon",
         "url": "https://www.patreon.com/infusion"
       }
+    },
+    "node_modules/framer-motion": {
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.11.2.tgz",
+      "integrity": "sha512-IrwuC9regNOU99JoM/Z62CAMA3awGV6AcF7e3bcgXk/ZoNlGSt5aVq0J7UAwtLmCkwVlRvBkiMnvv2mZ1GW2pg==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/framer-motion/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
     },
     "node_modules/fresh": {
       "version": "0.5.2",

--- a/frontend/src/utils/roles.js
+++ b/frontend/src/utils/roles.js
@@ -1,11 +1,13 @@
 import { supabase } from '../lib/api';
 
 export const ROLES = {
+  // app roles
+  ADMIN: 'admin',
+  USER: 'user',
+  // room permissions
   HOST: 'HOST',
   PRESENTER: 'PRESENTER',
   GUEST: 'GUEST',
-  ADMIN: 'admin',
-  USER: 'user'
 };
 
 const subscribeToRoleChanges = (roomId, handleRoleChange) => {

--- a/frontend/src/views/Room.jsx
+++ b/frontend/src/views/Room.jsx
@@ -43,6 +43,7 @@ function Room() {
   const roomRef = useRef();
   const remoteStreamsRef = useRef(new Map());
   const currentUser = useSelector((state) => state.user);
+  const isUserAdmin = currentUser?.role === ROLES.ADMIN;
   // const roomData = useSelector((state) => state.room);
   const dispatch = useDispatch();
   const { width = 0, height = 0 } = useWindowDimensions();
@@ -169,7 +170,6 @@ function Room() {
         () => { setRoomNotFound(true); },
       );
 
-      console.log('roomId', roomId);
       const newRoom = new WebRoom(JWT);
       const newParticipant = await newRoom.join();
 
@@ -336,7 +336,7 @@ function Room() {
   return (
     <>
       {
-        currentUser?.role === 'admin' && (
+        isUserAdmin && (
           <Button
             size="large"
             disabled={!localTracks.video}

--- a/frontend/src/views/Rooms.jsx
+++ b/frontend/src/views/Rooms.jsx
@@ -16,8 +16,8 @@ import {
 
 import { useDispatch, useSelector } from 'react-redux';
 import { supabase } from '../lib/api';
-import { createRoom, addRoomToDb } from '../actions';
-
+import { createRoom, addRoomToDb, giveUserRoleOnRoom } from '../actions';
+import { ROLES } from '../utils/roles';
 import RoomsList from '../components/RoomsList';
 
 function Rooms() {
@@ -100,6 +100,20 @@ function Rooms() {
   useEffect(() => {
     setUser(currentUser);
   }, [currentUser]);
+
+  const handleAdminHostPermission = async () => {
+    if (roomsList) {
+      roomsList.forEach(async (room) => {
+        const roomId = room.providerId;
+        if (currentUser?.role === ROLES.ADMIN) {
+          await giveUserRoleOnRoom(currentUser.email, roomId, ROLES.HOST);
+        }
+      });
+    }
+  };
+  useEffect(() => {
+    handleAdminHostPermission();
+  }, [roomsList]);
 
   useEffect(() => {
     const getRoomsList = async () => {


### PR DESCRIPTION
fixes #187 
When an administrator user logs in, they are granted host permission for all existing rooms. If a new room is created, they are also granted host permission for it. A record is added to the rooms-data database with the admin's userEmail and permissionId 1 (which is the HOST permission id in the rooms-permission database), and the room's id as the providerId.
