### PR TITLE
185 block a specific guest

### DIFF
--- a/frontend/src/components/ParticipantsCollection.jsx
+++ b/frontend/src/components/ParticipantsCollection.jsx
@@ -22,6 +22,7 @@ function ParticipantsCollection(props) {
     children,
     localParticipant,
     permissionRole,
+    isEnableToUnmute,
   } = props;
 
   const [currentPage, setCurrentPage] = useState(1);
@@ -63,6 +64,10 @@ function ParticipantsCollection(props) {
 
   const onClickRemove = (r) => {
     localParticipant.removeRemoteParticipant(r);
+  };
+
+  const onClickMute = (r, isMuted) => {
+    localParticipant.blockMuteRemoteParticipant(r, isMuted);
   };
 
   // const handleParticipantSelection = (participant) => {
@@ -141,6 +146,7 @@ function ParticipantsCollection(props) {
               isSpeaking={speaking || false}
               name={name}
               onClick={() => onClickRemove(name)}
+              onClickMute={() => onClickMute(name, audioMuted)}
               // style={selectedParticipant === name
               //   ? selectedParticipantStyle : normalParticipantStyle}
               // onClick={() => handleParticipantSelection(name)}
@@ -187,6 +193,7 @@ ParticipantsCollection.propTypes = {
   participantsCount: PropTypes.number,
   localParticipant: LocalParticipant,
   permissionRole: PropTypes.string,
+  isEnableToUnmute: PropTypes.bool,
 };
 
 ParticipantsCollection.defaultProps = {
@@ -198,6 +205,7 @@ ParticipantsCollection.defaultProps = {
   participantsCount: 1,
   localParticipant: null,
   permissionRole: ROLES.GUEST,
+  isEnableToUnmute: true,
 };
 
 export default ParticipantsCollection;

--- a/frontend/src/components/RoomControls.jsx
+++ b/frontend/src/components/RoomControls.jsx
@@ -24,16 +24,19 @@ function RoomControls(props) {
     updateLocalTracksMuted,
     leaveRoom,
     disabled,
-    permissionRole
+    permissionRole,
+    isEnableToUnmute,
   } = props;
 
   const toggleMuteTrack = (t) => {
-    if (t.muted) {
-      t.unmute();
-      updateLocalTracksMuted(t.kind, false);
-    } else {
-      t.mute();
-      updateLocalTracksMuted(t.kind, true);
+    if(isEnableToUnmute) {
+      if (t.muted) {
+        t.unmute();
+        updateLocalTracksMuted(t.kind, false);
+      } else {
+        t.mute();
+        updateLocalTracksMuted(t.kind, true);
+      }
     }
   };
 
@@ -75,11 +78,11 @@ function RoomControls(props) {
         <div style={{ padding: '2px' }}>
           <Button
             size="large"
-            disabled={!localTracks.audio}
+            disabled={!localTracks.audio || !isEnableToUnmute}
             onClick={() => toggleMuteTrack(localTracks.audio)}
           >
             {!localTracks.audio || localTracks.audio.muted ? (
-              <MicOffOutlinedIcon />
+              <MicOffOutlinedIcon color={isEnableToUnmute ? '' : 'error'}/>
             ) : (
               <MicIcon />
             )}
@@ -130,6 +133,7 @@ RoomControls.propTypes = {
   disabled: PropTypes.bool,
   isSharingScreen: PropTypes.bool,
   permissionRole: PropTypes.string,
+  isEnableToUnmute: PropTypes.bool,
 };
 
 RoomControls.defaultProps = {
@@ -137,6 +141,7 @@ RoomControls.defaultProps = {
   disabled: true,
   isSharingScreen: false,
   permissionRole: 'GUEST',
+  isEnableToUnmute: true,
 };
 
 export default RoomControls;

--- a/frontend/src/components/Video.jsx
+++ b/frontend/src/components/Video.jsx
@@ -6,10 +6,12 @@ import {
   IconButton,
 } from '@mui/material';
 import {
+  KeyboardVoiceRounded as KeyboardVoiceRoundedIcon,
   MicOffOutlined as MicOffOutlinedIcon,
   PushPinOutlined as PushPinOutlinedIcon,
   PushPinRounded as PushPinRoundedIcon,
   DeleteRounded as DeleteOutlineIcon,
+  TroubleshootRounded,
 } from '@mui/icons-material';
 import ParticipantInfo from './ParticipantInfo';
 import logo from '../assets/MVDTSC.png';
@@ -28,6 +30,7 @@ function Video(props) {
     width,
     height,
     onClick,
+    onClickMute,
     style,
     permissionRole,
   } = props;
@@ -90,19 +93,21 @@ function Video(props) {
       {name && (
       <ParticipantInfo name={name} parentHeight={height} />
       )}
-      {isAudioMuted && (
+      {(isAudioMuted || permissionRole === ROLES.HOST) && (
         <IconButton
+          disabled={!(permissionRole === ROLES.HOST)}
+          onClick={() => onClickMute(name, isAudioMuted)}
           disableRipple
           sx={{
             position: 'absolute',
             top: 10,
             right: 10,
-            color: 'white',
+            color: 'white !important',
             bgcolor: 'rgba(0, 0, 0, 0.2)',
             border: '2px solid',
           }}
         >
-          <MicOffOutlinedIcon sx={{ ml: '2px' }} />
+          { isAudioMuted ? <MicOffOutlinedIcon sx={{ ml: '2px' }} /> : <KeyboardVoiceRoundedIcon sx={{ ml: '2px' }} /> }
         </IconButton>
       )}
       {permissionRole === ROLES.HOST && (
@@ -152,6 +157,7 @@ Video.propTypes = {
   height: PropTypes.number,
   name: PropTypes.string,
   onClick: PropTypes.func,
+  onClickMute: PropTypes.func,
   style: PropTypes.shape({}),
   permissionRole: PropTypes.string,
 };
@@ -167,6 +173,7 @@ Video.defaultProps = {
   width: 160,
   height: 90,
   onClick: () => {},
+  onClickMute: () => {},
   style: {},
   permissionRole: ROLES.GUEST,
 };

--- a/frontend/src/lib/webrtc.js
+++ b/frontend/src/lib/webrtc.js
@@ -120,6 +120,23 @@ export class LocalParticipant extends Participant {
     }
   }
 
+  async blockMuteRemoteParticipant(participantId, isMuted) {
+    const eventType = 'BlockMuteRemoteParticipant';
+    const eventData = {
+      participantId,
+      isMuted,
+    };
+    const payload = JSON.stringify({
+      type: eventType,
+      data: eventData,
+    });
+    try {
+      await this.provider.publishCustomEvent(payload);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
   /**
    * Unpublish a list of local wrapped Tracks from the room.
    * The function also stops the tracks.
@@ -206,6 +223,9 @@ export class Room extends EventEmitter {
         const resp = JSON.parse(event.payload);
         if (resp.type === 'RemoveRemoteParticipant') {
           this.emit('RemoveRemoteParticipant', resp.data);
+        }
+        if (resp.type === 'BlockMuteRemoteParticipant') {
+          this.emit('BlockMuteRemoteParticipant', resp.data);
         }
       },
     );

--- a/frontend/src/views/Room.jsx
+++ b/frontend/src/views/Room.jsx
@@ -58,6 +58,7 @@ function Room() {
   const paddingY = height < 600 ? 10 : 40;
   const paddingX = width < 800 ? 40 : 60;
   const navigate = useNavigate();
+  const [isEnableToUnmute, setIsEnableToUnmute] = useState(true);
 
   // To add a new criteria to the comparator you need to
   // Decide if it's higher or lower pririoty compared to the already established
@@ -151,6 +152,7 @@ function Room() {
       participantsCount={participantsCount}
       localParticipant={localParticipant}
       permissionRole={userRole}
+      isEnableToUnmute={isEnableToUnmute}
     >
       {remoteStreams.filter((p) => !p.isSharingScreen)}
     </ParticipantsCollection>
@@ -301,6 +303,13 @@ function Room() {
         setLocalTracks(newLocalTracks);
         subscribeToRemoteStreams(newRoom);
         subscribeToRoleChanges(roomId, handleRoleChange);
+
+        newRoom.on('BlockMuteRemoteParticipant', (resp) => {
+          if (resp.participantId === newParticipant.displayName && currentUser.role !== ROLES.ADMIN) {
+            setIsEnableToUnmute(resp.isMuted);
+            newLocalTracks.audio.mute();
+          }
+        });
       } else {
         setErrorJoiningRoom(true);
         throw new Error("A duplicate session has been detected.");
@@ -404,7 +413,8 @@ function Room() {
         >
           ADD USER
         </Button>
-      )}
+        )
+      }
 
       {roomNotFound && <Navigate to="/rooms/404" />}
       {room ? (
@@ -449,6 +459,7 @@ function Room() {
               updateLocalTracksMuted={updateLocalTracksMuted}
               leaveRoom={leaveRoom}
               disabled={!room}
+                isEnableToUnmute={isEnableToUnmute}
             />
             <Button
               variant="contained"


### PR DESCRIPTION
fix #185 

A new button should be added next to the name of the participant and the quick out button that allows the moderator to block a specific guest from unmuting himself.
The blocked guest should not be able to unmute himself on the call, and the unmute/mute button should be blocked on his screen.
All other participants should be able to mute and unmute themselves as usual.