### PR TITLE
Implement chat filter using the "bad-words" JS library and ensure that the implementation provides an easy way to change the library used for filtering words

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.3.2",
+        "bad-words": "^3.0.4",
         "framer-motion": "^10.10.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -2117,6 +2118,22 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+    },
+    "node_modules/bad-words": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.4.tgz",
+      "integrity": "sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==",
+      "dependencies": {
+        "badwords-list": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/badwords-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
+      "integrity": "sha512-oWhaSG67e+HQj3OGHQt2ucP+vAPm1wTbdp2aDHeuh4xlGXBdWwzZ//pfu6swf5gZ8iX0b7JgmSo8BhgybbqszA=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.3.2",
+    "bad-words": "^3.0.4",
     "framer-motion": "^10.10.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/frontend/src/components/Chat.jsx
+++ b/frontend/src/components/Chat.jsx
@@ -44,7 +44,7 @@ function Chat() {
   // fue eliminado por contenido inapropiado, sino devuelve el contenido del mensaje original
   const filterContent = (hasBadWords) => {
     const filteredContent = hasBadWords
-      ? "This message was deleted due to inappropiate language"
+      ? "This message was deleted due to inappropriate language"
       : content;
 
     return filteredContent;


### PR DESCRIPTION
fix #241 
- When a user sends a message using offensive language, instead of sending the message, it will appear "This message was deleted due to inappropriate language".
- This implementation should be done in a way that the library that provides the filter can be changed easily. Please let me know if there is a better implementation to accomplish this.