### PR TITLE
184 block all guests from unmuting

### DIFF
--- a/frontend/src/components/RoomControls.jsx
+++ b/frontend/src/components/RoomControls.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { React, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 
@@ -47,6 +47,15 @@ function RoomControls(props) {
     }
   };
 
+  useEffect(() => {
+    if (!isEnableToUnmute && localTracks.audio) {
+      setTimeout(function() {
+        localTracks.audio.mute();
+        updateLocalTracksMuted(localTracks.audio.kind, true);
+      }, 500);
+    }
+  }, [localTracks.audio]);
+
   const endCall = () => {
     leaveRoom();
     navigate('/rooms');
@@ -94,7 +103,7 @@ function RoomControls(props) {
             disabled={!localTracks.audio || !isEnableToUnmute}
             onClick={() => toggleMuteTrack(localTracks.audio)}
           >
-            {!localTracks.audio || localTracks.audio.muted ? (
+            {!localTracks.audio || localTracks.audio.muted || !isEnableToUnmute ? (
               <MicOffOutlinedIcon color={isEnableToUnmute ? '' : 'error'}/>
             ) : (
               <MicIcon />

--- a/frontend/src/components/RoomControls.jsx
+++ b/frontend/src/components/RoomControls.jsx
@@ -11,9 +11,12 @@ import {
   Cancel as CancelIcon,
   ScreenShare as ScreenShareIcon,
   StopScreenShare as StopScreenShareIcon,
+  HeadsetMic as HeadsetMicIcon,
+  HeadsetOff as HeadsetOffIcon,
 } from '@mui/icons-material';
+import { LocalParticipant } from '@mux/spaces-web';
 import { ROLES } from '../utils/roles';
-
+import { setGuestMuted } from '../utils/room';
 function RoomControls(props) {
   const navigate = useNavigate();
 
@@ -26,6 +29,10 @@ function RoomControls(props) {
     disabled,
     permissionRole,
     isEnableToUnmute,
+    localParticipant,
+    isBlockedRemotedGuest,
+    setIsBlockedRemotedGuest,
+
   } = props;
 
   const toggleMuteTrack = (t) => {
@@ -48,6 +55,12 @@ function RoomControls(props) {
   const shareScreen = async () => {
     updateScreenShare();
   };
+
+  const blockMuteAllParticipants = () => {
+    localParticipant.blockMuteAllRemoteParticipants(!isBlockedRemotedGuest);
+    setIsBlockedRemotedGuest(!isBlockedRemotedGuest);
+    setGuestMuted(!isBlockedRemotedGuest);
+  }
 
   return (
     <ButtonGroup
@@ -108,6 +121,25 @@ function RoomControls(props) {
           </Tooltip>
         )
       }
+      {
+        (permissionRole === ROLES.HOST) && (
+          <Tooltip title={!isBlockedRemotedGuest ? 'Mute all Guests' : 'Unmute all Guests'}>
+            <div style={{ padding: '2px' }}>
+              <Button
+                size="large"
+                hover="onHoverTest"
+                onClick={() => blockMuteAllParticipants()}
+              >
+                {!isBlockedRemotedGuest ? (
+                  <HeadsetOffIcon />
+                ) : (
+                  <HeadsetMicIcon />
+                )}
+              </Button>
+            </div>
+          </Tooltip>
+        )
+      }
 
       <Tooltip title="Leave room">
         <div style={{ padding: '2px' }}>
@@ -134,6 +166,9 @@ RoomControls.propTypes = {
   isSharingScreen: PropTypes.bool,
   permissionRole: PropTypes.string,
   isEnableToUnmute: PropTypes.bool,
+  localParticipant: LocalParticipant,
+  setIsBlockedRemotedGuest: PropTypes.func.isRequired,
+  isBlockedRemotedGuest: PropTypes.bool,
 };
 
 RoomControls.defaultProps = {
@@ -142,6 +177,8 @@ RoomControls.defaultProps = {
   isSharingScreen: false,
   permissionRole: 'GUEST',
   isEnableToUnmute: true,
+  localParticipant: null,
+  isBlockedRemotedGuest: false,
 };
 
 export default RoomControls;

--- a/frontend/src/lib/webrtc.js
+++ b/frontend/src/lib/webrtc.js
@@ -137,6 +137,22 @@ export class LocalParticipant extends Participant {
     }
   }
 
+  async blockMuteAllRemoteParticipants(blockMuted) {
+    const eventType = 'BlockMuteAllRemoteParticipants';
+    const eventData = {
+      blockMuted,
+    };
+    const payload = JSON.stringify({
+      type: eventType,
+      data: eventData,
+    });
+    try {
+      await this.provider.publishCustomEvent(payload);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
   /**
    * Unpublish a list of local wrapped Tracks from the room.
    * The function also stops the tracks.
@@ -226,6 +242,9 @@ export class Room extends EventEmitter {
         }
         if (resp.type === 'BlockMuteRemoteParticipant') {
           this.emit('BlockMuteRemoteParticipant', resp.data);
+        }
+        if (resp.type === 'BlockMuteAllRemoteParticipants') {
+          this.emit('BlockMuteAllRemoteParticipants', resp.data);
         }
       },
     );

--- a/frontend/src/utils/room.js
+++ b/frontend/src/utils/room.js
@@ -1,19 +1,5 @@
 import { supabase } from '../lib/api';
 
-// export async function getGuestMuted() {
-//   supabase
-//     .from('rooms')
-//     .select('guestMuted')
-//     .eq('id', 54)
-//     .then(result => {
-//       console.log(result.data[0].guestMuted);
-//       return result.data[0].guestMuted;
-//     })
-//     .catch(error => {
-//       console.error(error)
-//     });
-// };
-
 export async function getGuestMuted() {
   const urlParams = window.location.pathname;;
   const parts = urlParams.split("/");

--- a/frontend/src/utils/room.js
+++ b/frontend/src/utils/room.js
@@ -1,0 +1,47 @@
+import { supabase } from '../lib/api';
+
+// export async function getGuestMuted() {
+//   supabase
+//     .from('rooms')
+//     .select('guestMuted')
+//     .eq('id', 54)
+//     .then(result => {
+//       console.log(result.data[0].guestMuted);
+//       return result.data[0].guestMuted;
+//     })
+//     .catch(error => {
+//       console.error(error)
+//     });
+// };
+
+export async function getGuestMuted() {
+  const urlParams = window.location.pathname;;
+  const parts = urlParams.split("/");
+  const roomId = parts[2];
+  try {
+    const { data, error } = await supabase
+      .from('rooms')
+      .select('guestMuted')
+      .eq('providerId', roomId)
+    if (error) throw error
+    return data[0].guestMuted
+  } catch (error) {
+    console.error(error)
+    return null
+  }
+}
+
+export function setGuestMuted(guestMutedStatus) {
+  const urlParams = window.location.pathname;;
+  const parts = urlParams.split("/");
+  const roomId = parts[2];
+  supabase
+    .from('rooms')
+    .update({ guestMuted: guestMutedStatus })
+    .eq('providerId', roomId)
+    .then(result => {
+    })
+    .catch(error => {
+      console.error(error)
+    })
+};

--- a/frontend/src/views/Room.jsx
+++ b/frontend/src/views/Room.jsx
@@ -271,7 +271,6 @@ function Room() {
 
   const handleBlockMuteAllGuests = (resp, localTracks) => {
     if (currentUser.role !== ROLES.ADMIN) {
-      // setIsEnableToUnmute(resp.blockMuted);
       setIsEnableToUnmute(!resp.blockMuted);
       if(resp.blockMuted) {
         localTracks.audio.mute();
@@ -293,6 +292,9 @@ function Room() {
     );
     const guestMuted = await getGuestMuted();
     setIsBlockedRemotedGuest(guestMuted);
+    if (currentUser.role !== ROLES.ADMIN) {
+      setIsEnableToUnmute(!guestMuted);
+    }
     try {
       const newRoom = new WebRoom(JWT);
       const newParticipant = await newRoom.join();

--- a/frontend/src/views/Room.jsx
+++ b/frontend/src/views/Room.jsx
@@ -25,6 +25,7 @@ import ShareScreen from "../components/ShareScreen";
 import { TESTING_MODE } from "../lib/constants";
 import Chat from "../components/Chat";
 import { comparator, updateParticipantRoles } from "../utils/helpers";
+import { getGuestMuted } from '../utils/room';
 
 export async function roomLoader({ params }) {
   return params.roomId;
@@ -59,6 +60,7 @@ function Room() {
   const paddingX = width < 800 ? 40 : 60;
   const navigate = useNavigate();
   const [isEnableToUnmute, setIsEnableToUnmute] = useState(true);
+  const [isBlockedRemotedGuest , setIsBlockedRemotedGuest] = useState(false);
 
   // To add a new criteria to the comparator you need to
   // Decide if it's higher or lower pririoty compared to the already established
@@ -267,6 +269,18 @@ function Room() {
     }
   }
 
+  const handleBlockMuteAllGuests = (resp, localTracks) => {
+    if (currentUser.role !== ROLES.ADMIN) {
+      // setIsEnableToUnmute(resp.blockMuted);
+      setIsEnableToUnmute(!resp.blockMuted);
+      if(resp.blockMuted) {
+        localTracks.audio.mute();
+      }
+    } else {
+      setIsBlockedRemotedGuest(resp.blockMuted)
+    }
+  }
+
   const joinRoom = async () => {
     const JWT = await roomJWTprovider(
       roomId,
@@ -277,7 +291,8 @@ function Room() {
         setRoomNotFound(true);
       }
     );
-
+    const guestMuted = await getGuestMuted();
+    setIsBlockedRemotedGuest(guestMuted);
     try {
       const newRoom = new WebRoom(JWT);
       const newParticipant = await newRoom.join();
@@ -313,6 +328,7 @@ function Room() {
         subscribeToRoleChanges(roomId, handleRoleChange);
 
         newRoom.on('BlockMuteRemoteParticipant', (resp) => handleBlockMuteRemote(resp, newParticipant, newLocalTracks));
+        newRoom.on('BlockMuteAllRemoteParticipants', (resp) => handleBlockMuteAllGuests(resp, newLocalTracks));
       } else {
         setErrorJoiningRoom(true);
         throw new Error("A duplicate session has been detected.");
@@ -462,7 +478,10 @@ function Room() {
               updateLocalTracksMuted={updateLocalTracksMuted}
               leaveRoom={leaveRoom}
               disabled={!room}
-                isEnableToUnmute={isEnableToUnmute}
+              isEnableToUnmute={isEnableToUnmute}
+              localParticipant={localParticipant}
+              isBlockedRemotedGuest={isBlockedRemotedGuest}
+              setIsBlockedRemotedGuest={setIsBlockedRemotedGuest}
             />
             <Button
               variant="contained"


### PR DESCRIPTION
fix #184 
As an admin, I should be able to access the feature to block all guests from unmuting themselves during calls.
The feature should only block guests from unmuting themselves, while still allowing admins and presenters to unmute themselves.
The feature should be accessible thorugh one button in the control panel of the call