### PR TITLE
Redirect logged in users to '/rooms' when they navigate to '/'

### DIFF
--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -29,7 +29,11 @@ const router = createBrowserRouter([
     children: [
       {
         path: "",
-        element: <LandingPage />,
+        element: (
+          <AuthRoute>
+            <LandingPage />,
+          </AuthRoute>
+        )
       },
       {
         path: "/rooms",


### PR DESCRIPTION
Wrapping LandingPage into AuthRoute will force a redirect to `/rooms` if the user is signed in and tries to navigate to `/`, for example by clicking on the Hybridly logo in the header.